### PR TITLE
hot fix: tailwind custom colors overwriting other default colors

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ["./src/**/*.{html,js}", "./index.html"],
+  content: ["./src/**/*.{html,js}", "./*.html"],
   theme: {
     extend: {
       colors: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,12 @@
 module.exports = {
   content: ["./src/**/*.{html,js}", "./index.html"],
   theme: {
+    extend: {
+      colors: {
+        "custom-green": "#00672E",
+        "custom-bgcolor": "#EFECEA",
+      },
+    },
     fontFamily: {
       outfit: ["Outfit", "sans-serif"],
     },
@@ -14,10 +20,6 @@ module.exports = {
         lg: "8rem",
       },
     },
-    colors: {
-      "custom-green": "#00672E",
-      "custom-bgcolor": "#EFECEA"
-    },  
   },
   plugins: [],
 };


### PR DESCRIPTION
The custom colors had overwritten the default tailwind colors. This fix resolves the issue; custom colors were moved inside the extend in theme inside the tailwind config file to add the custom colors on existing colors and not overwrite them.